### PR TITLE
Update README.md

### DIFF
--- a/docker/compose/README.md
+++ b/docker/compose/README.md
@@ -7,6 +7,8 @@ Install Docker-Compose::
 
 Warning - never git commit your secret credentials to upstream!
 
+If you get an error while uninstalling six package, add '--ignore-installed six' parameter to above command.
+
 
 Install the Full Poppy stack (poppy_stack.yml)
 ----------------------------------------------


### PR DESCRIPTION
Some OS like El Capitan, Sierra returned error while installing docker-compose.
In my case "six" package was the probelm. 

Please review this.